### PR TITLE
Delete Account from Settings

### DIFF
--- a/backend/controllers/user/create.controller.js
+++ b/backend/controllers/user/create.controller.js
@@ -88,7 +88,13 @@ async function signInUser(req, res) {
     const user = req.body;
     try {
         const userExists = await ifUserExists(user.email);
+        
         if (!userExists) {
+            return res.status(400).send({ message: "Email doesn't exists" });
+        }
+
+        // If status = 'deleted' | 'invalid' means like user is not registered in database
+        if (!userExists || userExists.status !== 'active') {
             return res.status(400).send({ message: "Email doesn't exists" });
         }
 

--- a/backend/controllers/user/create.controller.js
+++ b/backend/controllers/user/create.controller.js
@@ -88,10 +88,6 @@ async function signInUser(req, res) {
     const user = req.body;
     try {
         const userExists = await ifUserExists(user.email);
-        
-        if (!userExists) {
-            return res.status(400).send({ message: "Email doesn't exists" });
-        }
 
         // If status = 'deleted' | 'invalid' means like user is not registered in database
         if (!userExists || userExists.status !== 'active') {

--- a/backend/controllers/userDetails/delete.controller.js
+++ b/backend/controllers/userDetails/delete.controller.js
@@ -1,0 +1,33 @@
+const Users = require('../../models/user.mongo');
+
+async function deleteUser( req, res ) {
+
+    const userId = req.user.uid;
+    try {
+        // Update User Status to 'deleted'
+        const userChanges = {
+          status: 'deleted',
+          isGoogleAuth: false,
+          isVerified: false,
+          updated_at: Date.now()
+        }
+
+        const updatedUser = await Users.findByIdAndUpdate(userId, userChanges);
+        
+        if (!updatedUser) {
+          throw new Error(`User: ${ userId } not found`);
+        }
+
+        res.clearCookie('access_token');
+
+        return res.status(200).send({
+          status: 200,
+          message: `User: ${ userId } deleted successfully`,
+        });
+
+    } catch (error) {
+        console.error('Error updating user:', error);
+    }
+}
+
+module.exports = { deleteUser };

--- a/backend/controllers/userDetails/delete.controller.js
+++ b/backend/controllers/userDetails/delete.controller.js
@@ -30,7 +30,9 @@ async function deleteUser( req, res ) {
         });
 
     } catch (error) {
-        console.error('Error updating user:', error);
+        logger.error(error);
+
+        return res.status(500).send({ message: 'Internal Server Error :(' });
     }
 }
 

--- a/backend/controllers/userDetails/delete.controller.js
+++ b/backend/controllers/userDetails/delete.controller.js
@@ -2,7 +2,11 @@ const Users = require('../../models/user.mongo');
 
 async function deleteUser( req, res ) {
 
-    const userId = req.user.uid;
+    if (!req.isAuth) {
+        return res.status(401).send({ message: 'Unauthorised access' });
+    }
+
+    const { uid } = req.user;
     try {
         // Update User Status to 'deleted'
         const userChanges = {
@@ -12,17 +16,17 @@ async function deleteUser( req, res ) {
           updated_at: Date.now()
         }
 
-        const updatedUser = await Users.findByIdAndUpdate(userId, userChanges);
+        const updatedUser = await Users.findByIdAndUpdate(uid, userChanges);
         
         if (!updatedUser) {
-          throw new Error(`User: ${ userId } not found`);
+          throw new Error(`User: ${ uid } not found`);
         }
 
         res.clearCookie('access_token');
 
         return res.status(200).send({
           status: 200,
-          message: `User: ${ userId } deleted successfully`,
+          message: `User: ${ uid } deleted successfully`,
         });
 
     } catch (error) {

--- a/backend/controllers/userDetails/fetch.controller.js
+++ b/backend/controllers/userDetails/fetch.controller.js
@@ -135,8 +135,13 @@ async function fetchInterestedTrips(req, res) {
 }
 
 async function getUserDetails(req, res) {
+
+    
     let uid;
     if (req.route.path === '/') {
+        if (!req.isAuth) {
+            return res.status(401).send({ message: 'Unauthorised access' });
+        }
         uid = req.user.uid;
     } else if (req.route.path === '/:uid') {
         uid = req.params.uid;

--- a/backend/routes/userDetails.js
+++ b/backend/routes/userDetails.js
@@ -5,6 +5,7 @@ const {
     fetchOngoingTrips, fetchCompletedTrips, fetchInterestedTrips, getUserDetails,
 } = require('../controllers/userDetails/fetch.controller');
 const { postUserDetails } = require('../controllers/userDetails/post.controller');
+const { deleteUser } = require('../controllers/userDetails/delete.controller');
 
 const userDetailsRouter = Router();
 
@@ -13,6 +14,8 @@ userDetailsRouter.use(bodyParser.urlencoded({ extended: true }));
 
 userDetailsRouter.get('/', getUserDetails);
 userDetailsRouter.get('/:uid', getUserDetails);
+
+userDetailsRouter.delete('/', deleteUser);
 
 userDetailsRouter.get('/:uid/trips/ongoing', fetchOngoingTrips);
 userDetailsRouter.get('/:uid/trips/completed', fetchCompletedTrips);

--- a/frontend/src/pages/AccountSetting/Components/DeleteAccountModal/DeleteAccountModal.js
+++ b/frontend/src/pages/AccountSetting/Components/DeleteAccountModal/DeleteAccountModal.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import Modal from '../../../../modules/ui/Modal/Modal';
 import {
     DeleteButton,
@@ -8,9 +10,33 @@ import {
 } from './DeleteAccountModalStyles';
 import { useRecoilState } from 'recoil';
 import { ShowDeleteModalState } from '../../states/ShowDeleteModalState';
+import { backendOrigin } from '../../../../frontend.config';
+import { useAuth } from '../../../../context/Auth/useAuth';
 
 export default function DeleteAccountModal({ isVisible }) {
     const [, setDeleteModalState] = useRecoilState(ShowDeleteModalState);
+    const navigate = useNavigate();
+    
+    const { logoutAuth } = useAuth();
+
+    const handleDelete = async () => {
+        try {
+            const instance = axios.create({
+                baseURL: backendOrigin,
+                withCredentials: true,
+            });
+            const response = await instance.delete(`/account`);
+            if (response.status === 200) {
+                logoutAuth(); // Nullify the auth state
+                navigate('/');
+            } else {
+                throw new Error('Error deleting user: ' + response.statusText);
+            }
+        } catch (error) {
+            console.error('DELETE request failed:', error);
+        }
+    };
+
 
     return (
         <Modal
@@ -26,7 +52,7 @@ export default function DeleteAccountModal({ isVisible }) {
                     note that this change once done can't be reverted.
                 </StyledContent>
                 <StyledBottom>
-                    <DeleteButton>Delete</DeleteButton>
+                    <DeleteButton onClick={ handleDelete }>Delete</DeleteButton>
                 </StyledBottom>
             </StyledWrapper>
         </Modal>


### PR DESCRIPTION
### Summary
In the Settings page, when the user clicks on the Delete modal button the account will be deleted.
  1.  Change user status to 'deleted'
  2.  Set Auth states to null
  3.  When user tries to sign-in again he will not be able to, an exception will be thrown, since the account will be logically deleted from database. 

### Tests
With postman I tested the different related endpoints, where all of them worked. 
  - Deleting the user (DELETE to the /account endpoint)
  - Re-sign-in with the deleted user to verify the exception thrown
  - Trying different fetchs to related endpoints like /account, /account:uid



